### PR TITLE
Smarter Asset Inclusion

### DIFF
--- a/config-sample.php
+++ b/config-sample.php
@@ -46,6 +46,9 @@ $simulateLoggedOutUser = false;
 
 $inDevelopment = false; // This will basically always be false, StageBloc uses this internally
 
+// These files should not be included in the page or submitted to the theme
+$jsFileBlacklist = ['gulpfile.js', 'Gruntfile.js'];
+
 // Setup our StageBloc OAuth object
 $stagebloc = new Services_StageBloc($clientId, $clientSecret, $redirectUri, $inDevelopment);
 $stagebloc->setAccessToken($accessToken);

--- a/config-sample.php
+++ b/config-sample.php
@@ -53,5 +53,3 @@ $jsFileBlacklist = ['gulpfile.js', 'Gruntfile.js'];
 $stagebloc = new Services_StageBloc($clientId, $clientSecret, $redirectUri, $inDevelopment);
 $stagebloc->setAccessToken($accessToken);
 $stagebloc->setResponseFormat('json');
-
-?>

--- a/submit_theme.php
+++ b/submit_theme.php
@@ -39,7 +39,7 @@ if ( isset($_COOKIE['theme']) )
 		$cssFiles = scandir($themePath . $themeToUse . '/' . $cssPath);
 		foreach ( $cssFiles as $cssFile )
 		{
-			if ( strpos($cssFile, '.css') !== false )
+			if ( preg_match('/\.css$/', $cssFile) )
 			{
 				$css .= file_get_contents($themePath . $themeToUse . '/' . $cssPath . $cssFile);
 			}
@@ -62,7 +62,7 @@ if ( isset($_COOKIE['theme']) )
 		$jsFiles = scandir($themePath . $themeToUse . '/' . $jsPath);
 		foreach ( $jsFiles as $jsFile )
 		{
-			if ( strpos($jsFile, '.js') !== false )
+			if ( preg_match('/\.js$/', $jsFile) && ! in_array($jsFile, $jsFileBlacklist) )
 			{
 				$js .= file_get_contents($themePath . $themeToUse . '/' . $jsPath . $jsFile);
 			}

--- a/theme_view.php
+++ b/theme_view.php
@@ -76,7 +76,7 @@ try
 			$cssFiles = scandir($themePath . $themeToUse . '/' . $cssPath);
 			foreach ( $cssFiles as $cssFile )
 			{
-				if ( strpos($cssFile, '.css') !== false )
+				if ( preg_match('/\.css$/', $cssFile) )
 				{
 					// This method will dump the CSS into the page itself and probably isn't very useful
 					//$renderedTheme = str_replace('</head>', '<style>' . file_get_contents($themePath . $themeToUse . '/' . $cssPath . $cssFile) . '</style></head>', $renderedTheme);
@@ -100,7 +100,7 @@ try
 			$jsFiles = scandir($themePath . $themeToUse . '/' . $jsPath);
 			foreach ( $jsFiles as $jsFile )
 			{
-				if ( strpos($jsFile, '.js') !== false )
+				if ( preg_match('/\.js$/', $jsFile) && ! in_array($jsFile, $jsFileBlacklist) )
 				{
 					$renderedTheme = str_replace('</head>', '<script src="' . $themePath . $themeToUse . '/' . $jsPath . $jsFile . '"></script></head>', $renderedTheme);
 				}


### PR DESCRIPTION
## Updates
- make sure the file ends with `.js` and `.css`, not just includes it (e.g., don't include `.json`, `.css.old`, etc)
- add blacklist of common root-level `.js` files that should not be included on the site (from gulp or grunt)